### PR TITLE
Fix: Ensure search endpoint returns results in alphabetical order

### DIFF
--- a/src/main/java/database/search/GroupSearchParams.java
+++ b/src/main/java/database/search/GroupSearchParams.java
@@ -99,6 +99,7 @@ public class GroupSearchParams {
                   LEFT JOIN  locations on events.location_id = locations.id
                   LEFT JOIN location_group_map on groups.id = location_group_map.group_id
                   LEFT JOIN locations as locs on location_group_map.location_id = locs.id
+                  ORDER BY groups.name ASC
           
         """;
     return query;

--- a/src/test/java/app/service/SearchServiceIntegrationTest.java
+++ b/src/test/java/app/service/SearchServiceIntegrationTest.java
@@ -214,16 +214,19 @@ public class SearchServiceIntegrationTest {
     LinkedHashMap<String, String> params = new LinkedHashMap<>();
     GroupSearchResult result = searchService.getGroups(params, testConnectionProvider);
 
-    Group[] groups = result.getGroupData().values().toArray(new Group[0]);
-    for (int i = 1; i < groups.length; i++) {
-        String prevName = groups[i - 1].getName();
-        String currName = groups[i].getName();
+    Iterator<Group> iterator = result.getGroupData().values().iterator();
+    Group prev = iterator.hasNext() ? iterator.next() : null;
+    while (iterator.hasNext()) {
+        Group curr = iterator.next();
+        String prevName = prev.getName();
+        String currName = curr.getName();
         if (prevName != null && currName != null) {
             assertTrue(
                 prevName.compareToIgnoreCase(currName) <= 0,
                 "Groups out of order: " + prevName + " after " + currName
             );
         }
+        prev = curr;
     }
 }
 }

--- a/src/test/java/app/service/SearchServiceIntegrationTest.java
+++ b/src/test/java/app/service/SearchServiceIntegrationTest.java
@@ -208,4 +208,26 @@ public class SearchServiceIntegrationTest {
     assertEquals(2, searchResult.countEvents());
     assertEquals(1, searchResult.countGroups());
   }
+
+  @Test
+  public void testGroupsAreOrderedAlphabetically() {
+    LinkedHashMap<String, String> params = new LinkedHashMap<>();
+    GroupSearchResult result = searchService.getGroups(params, testConnectionProvider);
+    
+    List<String> groupNames = result.getGroupData().values().stream()
+        .map(Group::getName)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+    
+    if (groupNames.size() < 2) {
+        return; // Not enough groups to check order
+    }
+    
+    for (int i = 1; i < groupNames.size(); i++) {
+        assertTrue(
+            groupNames.get(i - 1).compareToIgnoreCase(groupNames.get(i)) <= 0,
+            "Groups out of order: " + groupNames.get(i - 1) + " after " + groupNames.get(i)
+        );
+    }
+  }
 }

--- a/src/test/java/app/service/SearchServiceIntegrationTest.java
+++ b/src/test/java/app/service/SearchServiceIntegrationTest.java
@@ -214,19 +214,20 @@ public class SearchServiceIntegrationTest {
     LinkedHashMap<String, String> params = new LinkedHashMap<>();
     GroupSearchResult result = searchService.getGroups(params, testConnectionProvider);
 
-    Iterator<Group> iterator = result.getGroupData().values().iterator();
-    Group prev = iterator.hasNext() ? iterator.next() : null;
-    while (iterator.hasNext()) {
-        Group curr = iterator.next();
-        String prevName = prev.getName();
-        String currName = curr.getName();
+    Group[] previous = new Group[1];
+
+    result.getGroupData().forEach((id, current) -> {
+      if (previous[0] != null) {
+        String prevName = previous[0].getName();
+        String currName = current.getName();
         if (prevName != null && currName != null) {
-            assertTrue(
-                prevName.compareToIgnoreCase(currName) <= 0,
-                "Groups out of order: " + prevName + " after " + currName
-            );
+          assertTrue(
+            prevName.compareToIgnoreCase(currName) <= 0,
+            "Groups out of order: " + prevName + " after " + currName
+          );
         }
-        prev = curr;
-    }
-}
+      }
+      previous[0] = current;
+    });
+  }
 }

--- a/src/test/java/app/service/SearchServiceIntegrationTest.java
+++ b/src/test/java/app/service/SearchServiceIntegrationTest.java
@@ -210,24 +210,20 @@ public class SearchServiceIntegrationTest {
   }
 
   @Test
-  public void testGroupsAreOrderedAlphabetically() {
+  public void testGroupsAreOrderedAlphabetically() throws Exception {
     LinkedHashMap<String, String> params = new LinkedHashMap<>();
     GroupSearchResult result = searchService.getGroups(params, testConnectionProvider);
-    
-    List<String> groupNames = result.getGroupData().values().stream()
-        .map(Group::getName)
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
-    
-    if (groupNames.size() < 2) {
-        return; // Not enough groups to check order
+
+    Group[] groups = result.getGroupData().values().toArray(new Group[0]);
+    for (int i = 1; i < groups.length; i++) {
+        String prevName = groups[i - 1].getName();
+        String currName = groups[i].getName();
+        if (prevName != null && currName != null) {
+            assertTrue(
+                prevName.compareToIgnoreCase(currName) <= 0,
+                "Groups out of order: " + prevName + " after " + currName
+            );
+        }
     }
-    
-    for (int i = 1; i < groupNames.size(); i++) {
-        assertTrue(
-            groupNames.get(i - 1).compareToIgnoreCase(groupNames.get(i)) <= 0,
-            "Groups out of order: " + groupNames.get(i - 1) + " after " + groupNames.get(i)
-        );
-    }
-  }
+}
 }


### PR DESCRIPTION
Fix: This PR fixes a bug in the search endpoint to ensure that results are returned in alphabetical order.

Approach: Added an `ORDER BY groups.name ASC` clause to the `getQueryForAllResults()` method to ensure that results are sorted alphabetically by group name.

Closes #68